### PR TITLE
Allow scripting in files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ under the License.
   </parent>
 
   <artifactId>maven-scripting-plugin</artifactId>
-  <version>3.1.0</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>Apache Maven Scripting Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ under the License.
 
   <name>Apache Maven Scripting Plugin</name>
   <description>
-    The Maven Scripting Plugin is a plugin that wrapped the Scripting API accoring to JSR223.
+    The Maven Scripting Plugin is a plugin that wrapped the Scripting API according to JSR223.
     Add the scripting engines as dependencies of this plugin on its use.
   </description>
   <inceptionYear>2016</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,8 @@ under the License.
 
   <name>Apache Maven Scripting Plugin</name>
   <description>
-    The Maven Scripting Plugin is a plugin that wrapped the Scripting API accoring to JSR223
+    The Maven Scripting Plugin is a plugin that wrapped the Scripting API accoring to JSR223.
+    Add the scripting engines as dependencies of this plugin on its use.
   </description>
   <inceptionYear>2016</inceptionYear>
 
@@ -90,13 +91,6 @@ under the License.
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
       <scope>provided</scope>
-    </dependency>
-
-    <!-- ScriptEngines -->
-    <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-jsr223</artifactId>
-      <version>2.4.7</version>
     </dependency>
 
     <!-- Test -->

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ under the License.
   </parent>
 
   <artifactId>maven-scripting-plugin</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.1.0-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>Apache Maven Scripting Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ under the License.
   </parent>
 
   <artifactId>maven-scripting-plugin</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.0</version>
   <packaging>maven-plugin</packaging>
 
   <name>Apache Maven Scripting Plugin</name>

--- a/src/it/groovy-script-file-name/pom.xml
+++ b/src/it/groovy-script-file-name/pom.xml
@@ -37,6 +37,14 @@ under the License.
           <engineName>groovy</engineName>
           <scriptFile>test.groov</scriptFile>
         </configuration>
+        <dependencies>
+          <!-- ScriptEngines -->
+          <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-jsr223</artifactId>
+            <version>2.4.7</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/src/it/groovy-script-file-name/pom.xml
+++ b/src/it/groovy-script-file-name/pom.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.scripting.its</groupId>
+  <artifactId>groovy-script</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-scripting-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <engineName>groovy</engineName>
+          <scriptFile>test.groov</scriptFile>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/groovy-script-file-name/test.groov
+++ b/src/it/groovy-script-file-name/test.groov
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+(1..10).sum() + ' ' + project.artifactId

--- a/src/it/groovy-script-file/pom.xml
+++ b/src/it/groovy-script-file/pom.xml
@@ -1,0 +1,47 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.scripting.its</groupId>
+  <artifactId>groovy-script</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-scripting-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <engineName>groovy</engineName>
+          <script>
+          <![CDATA[
+            (1..10).sum() + ' ' + project.artifactId
+          ]]>
+          </script>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/groovy-script-file/pom.xml
+++ b/src/it/groovy-script-file/pom.xml
@@ -34,12 +34,8 @@ under the License.
         <artifactId>maven-scripting-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>
-          <engineName>groovy</engineName>
-          <script>
-          <![CDATA[
-            (1..10).sum() + ' ' + project.artifactId
-          ]]>
-          </script>
+          <!--engineName>groovy</engineName-->
+          <scriptFile>test.groovy</scriptFile>
         </configuration>
       </plugin>
     </plugins>

--- a/src/it/groovy-script-file/pom.xml
+++ b/src/it/groovy-script-file/pom.xml
@@ -37,6 +37,14 @@ under the License.
           <!--engineName>groovy</engineName-->
           <scriptFile>test.groovy</scriptFile>
         </configuration>
+        <dependencies>
+          <!-- ScriptEngines -->
+          <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-jsr223</artifactId>
+            <version>2.4.7</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/src/it/groovy-script-file/test.groovy
+++ b/src/it/groovy-script-file/test.groovy
@@ -1,1 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
 (1..10).sum() + ' ' + project.artifactId

--- a/src/it/groovy-script-file/test.groovy
+++ b/src/it/groovy-script-file/test.groovy
@@ -1,0 +1,1 @@
+(1..10).sum() + ' ' + project.artifactId

--- a/src/it/groovy-script/pom.xml
+++ b/src/it/groovy-script/pom.xml
@@ -41,6 +41,14 @@ under the License.
           ]]>
           </script>
         </configuration>
+        <dependencies>
+          <!-- ScriptEngines -->
+          <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-jsr223</artifactId>
+            <version>2.4.7</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/org/apache/maven/plugins/scripting/EvalMojo.java
+++ b/src/main/java/org/apache/maven/plugins/scripting/EvalMojo.java
@@ -41,7 +41,7 @@ import org.apache.maven.project.MavenProject;
 public class EvalMojo
     extends AbstractMojo
 {
-    @Parameter( required = true )
+    @Parameter
     private String engineName;
 
     /**

--- a/src/main/java/org/apache/maven/plugins/scripting/EvalMojo.java
+++ b/src/main/java/org/apache/maven/plugins/scripting/EvalMojo.java
@@ -1,3 +1,5 @@
+package org.apache.maven.plugins.scripting;
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -16,8 +18,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-package org.apache.maven.plugins.scripting;
 
 import java.io.File;
 
@@ -76,10 +76,10 @@ public class EvalMojo
          execute = constructExecute();
 
          bindings = new SimpleBindings();
-         bindings.put("project", project );
-         bindings.put("log", getLog() );
+         bindings.put( "project", project );
+         bindings.put( "log", getLog() );
 
-         result = execute.run(bindings);
+         result = execute.run( bindings );
 
          getLog().info( "Result:" );
          if ( result != null )
@@ -87,32 +87,33 @@ public class EvalMojo
            getLog().info( result.toString() );
          }
        }
-       catch (IllegalArgumentException e) // configuring the plugin failed
+       catch ( IllegalArgumentException e ) // configuring the plugin failed
        {
          throw new MojoExecutionException( e.getMessage(), e );
        }
-       catch (Exception e) // execution failure
+       catch ( Exception e ) // execution failure
        {
            throw new MojoFailureException( e.getMessage(), e );
        }
     }
 
-    private Execute constructExecute() throws IllegalArgumentException {
+    private Execute constructExecute() throws IllegalArgumentException
+    {
       Execute execute;
 
-      if (scriptFile != null)
+      if ( scriptFile != null )
       {
-         execute = new ExecuteFile(engineName, scriptFile);
+         execute = new ExecuteFile( engineName, scriptFile );
 
       }
       else if ( script != null )
       {
-         execute = new ExecuteString(engineName, script);
+         execute = new ExecuteString( engineName, script );
 
       }
       else
       {
-         throw new IllegalArgumentException("Missing script or scriptFile provided");
+         throw new IllegalArgumentException( "Missing script or scriptFile provided" );
       }
       return execute;
     }

--- a/src/main/java/org/apache/maven/plugins/scripting/EvalMojo.java
+++ b/src/main/java/org/apache/maven/plugins/scripting/EvalMojo.java
@@ -1,5 +1,3 @@
-package org.apache.maven.plugins.scripting;
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -19,10 +17,12 @@ package org.apache.maven.plugins.scripting;
  * under the License.
  */
 
-import javax.script.ScriptContext;
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
-import javax.script.ScriptException;
+package org.apache.maven.plugins.scripting;
+
+import java.io.File;
+
+import javax.script.Bindings;
+import javax.script.SimpleBindings;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -33,7 +33,7 @@ import org.apache.maven.project.MavenProject;
 
 /**
  * Evaluate the specified script
- * 
+ *
  * @author Robert Scholte
  * @since 3.0.0
  */
@@ -42,7 +42,7 @@ public class EvalMojo
     extends AbstractMojo
 {
     @Parameter( required = true )
-    private String engineName; // or map extension to engineName??
+    private String engineName;
 
     /**
      * When used, also specify the engineName
@@ -50,60 +50,70 @@ public class EvalMojo
     @Parameter
     private String script;
 
+    /**
+     * Provide the script as an external file as an alternative to &lt;script&gt;.
+     * When scriptFile provided the script is ignored.
+     * The file name extension identifies the script language to use, as of javax.script.ScriptEngineManager
+     * and {@linkplain "https://jcp.org/aboutJava/communityprocess/final/jsr223/index.html"}
+     */
+    @Parameter
+    private File scriptFile;
+
     // script variables
     @Parameter( defaultValue = "${project}", readonly = true )
     private MavenProject project;
-    
-    private ScriptEngineManager manager = new ScriptEngineManager();
 
     @Override
     public void execute()
         throws MojoExecutionException, MojoFailureException
     {
-        ScriptEngine engine = null;
-        
-        if ( script != null )
-        {
-            engine = getScriptEngine( engineName );
+       Execute execute;
+       Object result;
+       Bindings bindings;
 
-            if ( engine == null )
-            {
-                throw new MojoFailureException( "Missing scriptEngine" );
-            }
-        }
-        else
-        {
-            // from file
-        }
+       try
+       {
+         execute = constructExecute();
 
-        try
-        {
-            ScriptContext context = engine.getContext();
-            context.setAttribute( "project", project, ScriptContext.GLOBAL_SCOPE );
-            
-            Object result = engine.eval( script );
-            
-            getLog().info( "Result:" );
-            if ( result != null )
-            {
-                getLog().info( result.toString() );
-            }
-        }
-        catch ( ScriptException e )
-        {
-            throw new MojoExecutionException( e.getMessage(), e );
-        }
+         bindings = new SimpleBindings();
+         bindings.put("project", project );
+         bindings.put("log", getLog() );
+
+         result = execute.run(bindings);
+
+         getLog().info( "Result:" );
+         if ( result != null )
+         {
+           getLog().info( result.toString() );
+         }
+       }
+       catch (IllegalArgumentException e) // configuring the plugin failed
+       {
+         throw new MojoExecutionException( e.getMessage(), e );
+       }
+       catch (Exception e) // execution failure
+       {
+           throw new MojoFailureException( e.getMessage(), e );
+       }
     }
-    
-    private ScriptEngine getScriptEngine( String name )
-    {
-        if ( name == null ) 
-        {
-            return null;
-        }
-        else
-        {
-            return manager.getEngineByName( engineName );
-        }
+
+    private Execute constructExecute() throws IllegalArgumentException {
+      Execute execute;
+
+      if (scriptFile != null)
+      {
+         execute = new ExecuteFile(engineName, scriptFile);
+
+      }
+      else if ( script != null )
+      {
+         execute = new ExecuteString(engineName, script);
+
+      }
+      else
+      {
+         throw new IllegalArgumentException("Missing script or scriptFile provided");
+      }
+      return execute;
     }
 }

--- a/src/main/java/org/apache/maven/plugins/scripting/Execute.java
+++ b/src/main/java/org/apache/maven/plugins/scripting/Execute.java
@@ -1,3 +1,5 @@
+package org.apache.maven.plugins.scripting;
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -17,8 +19,6 @@
  * under the License.
  */
 
-package org.apache.maven.plugins.scripting;
-
 import javax.script.Bindings;
 import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
@@ -29,7 +29,8 @@ import javax.script.ScriptException;
  * Execute a script in the appropriate context and return its possibly null result
  * @author Rusi Popov
  */
-abstract class Execute {
+abstract class Execute
+{
 
   /**
    * @param bindings not null bindings to provide to the script to execute
@@ -37,14 +38,15 @@ abstract class Execute {
    * @throws IllegalArgumentException when the engine is not configured correctly
    * @throws ScriptException
    */
-  public final Object run(Bindings bindings) throws IllegalArgumentException, ScriptException {
+  public final Object run( Bindings bindings ) throws IllegalArgumentException, ScriptException
+  {
     ScriptEngine engine;
     ScriptEngineManager manager;
     ScriptContext context;
 
     manager = new ScriptEngineManager();
-    engine = constructEngine(manager);
-    context= engine.getContext();
+    engine = constructEngine( manager );
+    context = engine.getContext();
 
     context.setBindings( bindings, ScriptContext.GLOBAL_SCOPE );
 
@@ -58,12 +60,12 @@ abstract class Execute {
    * @return possibly null result of the script
    * @throws ScriptException
    */
-  protected abstract Object execute(ScriptEngine engine, ScriptContext context) throws ScriptException;
+  protected abstract Object execute( ScriptEngine engine, ScriptContext context ) throws ScriptException;
 
   /**
    * @param manager not null
    * @return non-null engine to execute the script
    * @throws IllegalArgumentException when no engine could be identified
    */
-  protected abstract ScriptEngine constructEngine(ScriptEngineManager manager) throws IllegalArgumentException;
+  protected abstract ScriptEngine constructEngine( ScriptEngineManager manager ) throws IllegalArgumentException;
 }

--- a/src/main/java/org/apache/maven/plugins/scripting/Execute.java
+++ b/src/main/java/org/apache/maven/plugins/scripting/Execute.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.maven.plugins.scripting;
+
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+
+/**
+ * Execute a script in the appropriate context and return its possibly null result
+ * @author Rusi Popov
+ */
+abstract class Execute {
+
+  /**
+   * @param bindings not null bindings to provide to the script to execute
+   * @return the possibly null result the script produced
+   * @throws IllegalArgumentException when the engine is not configured correctly
+   * @throws ScriptException
+   */
+  public final Object run(Bindings bindings) throws IllegalArgumentException, ScriptException {
+    ScriptEngine engine;
+    ScriptEngineManager manager;
+    ScriptContext context;
+
+    manager = new ScriptEngineManager();
+    engine = constructEngine(manager);
+    context= engine.getContext();
+
+    context.setBindings( bindings, ScriptContext.GLOBAL_SCOPE );
+
+    return execute( engine, context );
+  }
+
+  /**
+   * Execute the script
+   * @param engine not null
+   * @param context not null, initialized
+   * @return possibly null result of the script
+   * @throws ScriptException
+   */
+  protected abstract Object execute(ScriptEngine engine, ScriptContext context) throws ScriptException;
+
+  /**
+   * @param manager not null
+   * @return non-null engine to execute the script
+   * @throws IllegalArgumentException when no engine could be identified
+   */
+  protected abstract ScriptEngine constructEngine(ScriptEngineManager manager) throws IllegalArgumentException;
+}

--- a/src/main/java/org/apache/maven/plugins/scripting/ExecuteFile.java
+++ b/src/main/java/org/apache/maven/plugins/scripting/ExecuteFile.java
@@ -1,3 +1,5 @@
+package org.apache.maven.plugins.scripting;
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -17,8 +19,6 @@
  * under the License.
  */
 
-package org.apache.maven.plugins.scripting;
-
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
@@ -33,7 +33,8 @@ import javax.script.ScriptException;
  * to a valid engine name or not define any at all.
  * @author Rusi Popov
  */
-class ExecuteFile extends Execute {
+public class ExecuteFile extends Execute
+{
 
   /**
    * Not null, existing readable file with the script
@@ -50,12 +51,14 @@ class ExecuteFile extends Execute {
    * @param scriptFile not null
    * @throws IllegalArgumentException when the combination of parameters is incorrect
    */
-  public ExecuteFile(String engineName, File scriptFile) throws IllegalArgumentException {
-    if (scriptFile == null
-        || !scriptFile.isFile()
-        || !scriptFile.exists()
-        || !scriptFile.canRead()) {
-      throw new IllegalArgumentException("Expected an existing readable file \""+scriptFile+"\" provided");
+  public ExecuteFile( String engineName, File scriptFile ) throws IllegalArgumentException
+  {
+    if ( scriptFile == null
+         || !scriptFile.isFile()
+         || !scriptFile.exists()
+         || !scriptFile.canRead() )
+    {
+      throw new IllegalArgumentException( "Expected an existing readable file \"" + scriptFile + "\" provided" );
     }
     this.scriptFile = scriptFile;
 
@@ -69,13 +72,17 @@ class ExecuteFile extends Execute {
    * @throws ScriptException
    * @see org.apache.maven.plugins.scripting.Execute#execute(javax.script.ScriptEngine, javax.script.ScriptContext)
    */
-  protected Object execute(ScriptEngine engine, ScriptContext context) throws ScriptException {
+  protected Object execute( ScriptEngine engine, ScriptContext context ) throws ScriptException
+  {
     FileReader reader;
 
-    try {
-      reader = new FileReader(scriptFile);
-    } catch (IOException ex) {
-      throw new IllegalArgumentException(scriptFile+" caused:", ex);
+    try
+    {
+      reader = new FileReader( scriptFile );
+    }
+    catch ( IOException ex )
+    {
+      throw new IllegalArgumentException( scriptFile + " caused:", ex );
     }
     return engine.eval( reader, context );
   }
@@ -83,28 +90,35 @@ class ExecuteFile extends Execute {
   /**
    * @see org.apache.maven.plugins.scripting.Execute#constructEngine(javax.script.ScriptEngineManager)
    */
-  protected ScriptEngine constructEngine(ScriptEngineManager manager) throws IllegalArgumentException {
+  protected ScriptEngine constructEngine( ScriptEngineManager manager ) throws IllegalArgumentException
+  {
     ScriptEngine result;
     String extension;
     int position;
 
-    if ( engineName != null && !engineName.trim().isEmpty() ) {
+    if ( engineName != null && !engineName.trim().isEmpty() )
+    {
       result = manager.getEngineByName( engineName );
 
-      if ( result == null ) {
-        throw new IllegalArgumentException("No engine found by name \""+engineName+"\n");
+      if ( result == null )
+      {
+        throw new IllegalArgumentException( "No engine found by name \"" + engineName + "\n" );
       }
-    } else {
+    }
+    else
+    {
       extension = scriptFile.getName();
-      position = extension.indexOf(".");
+      position = extension.indexOf( "." );
 
-      if ( position >= 0 ) {
-        extension = extension.substring( position+1 );
+      if ( position >= 0 )
+      {
+        extension = extension.substring( position + 1 );
       }
       result = manager.getEngineByExtension( extension );
 
-      if ( result == null ) {
-        throw new IllegalArgumentException("No engine found by extension \""+extension+"\n");
+      if ( result == null )
+      {
+        throw new IllegalArgumentException( "No engine found by extension \"" + extension + "\n" );
       }
     }
     return result;

--- a/src/main/java/org/apache/maven/plugins/scripting/ExecuteFile.java
+++ b/src/main/java/org/apache/maven/plugins/scripting/ExecuteFile.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.maven.plugins.scripting;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+
+/**
+ * Execute a script held in a file. Use the engine name to override the engine if the file name does not refer/decode
+ * to a valid engine name or not define any at all.
+ * @author Rusi Popov
+ */
+class ExecuteFile extends Execute {
+
+  /**
+   * Not null, existing readable file with the script
+   */
+  private final File scriptFile;
+
+  /**
+   * Possibly null engine name
+   */
+  private final String engineName;
+
+  /**
+   * @param engineName optional engine name, used to override the engine selection from the file extension
+   * @param scriptFile not null
+   * @throws IllegalArgumentException when the combination of parameters is incorrect
+   */
+  public ExecuteFile(String engineName, File scriptFile) throws IllegalArgumentException {
+    if (scriptFile == null
+        || !scriptFile.isFile()
+        || !scriptFile.exists()
+        || !scriptFile.canRead()) {
+      throw new IllegalArgumentException("Expected an existing readable file \""+scriptFile+"\" provided");
+    }
+    this.scriptFile = scriptFile;
+
+    this.engineName = engineName;
+  }
+
+  /**
+   * @param engine
+   * @param context
+   * @return
+   * @throws ScriptException
+   * @see org.apache.maven.plugins.scripting.Execute#execute(javax.script.ScriptEngine, javax.script.ScriptContext)
+   */
+  protected Object execute(ScriptEngine engine, ScriptContext context) throws ScriptException {
+    FileReader reader;
+
+    try {
+      reader = new FileReader(scriptFile);
+    } catch (IOException ex) {
+      throw new IllegalArgumentException(scriptFile+" caused:", ex);
+    }
+    return engine.eval( reader, context );
+  }
+
+  /**
+   * @see org.apache.maven.plugins.scripting.Execute#constructEngine(javax.script.ScriptEngineManager)
+   */
+  protected ScriptEngine constructEngine(ScriptEngineManager manager) throws IllegalArgumentException {
+    ScriptEngine result;
+    String extension;
+    int position;
+
+    if ( engineName != null && !engineName.trim().isEmpty() ) {
+      result = manager.getEngineByName( engineName );
+
+      if ( result == null ) {
+        throw new IllegalArgumentException("No engine found by name \""+engineName+"\n");
+      }
+    } else {
+      extension = scriptFile.getName();
+      position = extension.indexOf(".");
+
+      if ( position >= 0 ) {
+        extension = extension.substring( position+1 );
+      }
+      result = manager.getEngineByExtension( extension );
+
+      if ( result == null ) {
+        throw new IllegalArgumentException("No engine found by extension \""+extension+"\n");
+      }
+    }
+    return result;
+  }
+}

--- a/src/main/java/org/apache/maven/plugins/scripting/ExecuteString.java
+++ b/src/main/java/org/apache/maven/plugins/scripting/ExecuteString.java
@@ -1,3 +1,5 @@
+package org.apache.maven.plugins.scripting;
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -17,8 +19,6 @@
  * under the License.
  */
 
-package org.apache.maven.plugins.scripting;
-
 import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
@@ -28,7 +28,8 @@ import javax.script.ScriptException;
  * Execute a script held in a string
  * @author Rusi Popov
  */
-class ExecuteString extends Execute {
+public class ExecuteString extends Execute
+{
 
   /**
    * Not null name of the engine to execute the script
@@ -45,14 +46,17 @@ class ExecuteString extends Execute {
    * @param script
    * @throws IllegalArgumentException
    */
-  public ExecuteString(String engineName, String script) throws IllegalArgumentException {
-    if (engineName == null || engineName.trim().isEmpty()) {
-      throw new IllegalArgumentException("Expected a non-empty engine name provided");
+  public ExecuteString( String engineName, String script ) throws IllegalArgumentException
+  {
+    if ( engineName == null || engineName.trim().isEmpty() )
+    {
+      throw new IllegalArgumentException( "Expected a non-empty engine name provided" );
     }
     this.engineName = engineName;
 
-    if (script == null || script.trim().isEmpty()) {
-      throw new IllegalArgumentException("Expected a non-empty script provided");
+    if ( script == null || script.trim().isEmpty() )
+    {
+      throw new IllegalArgumentException( "Expected a non-empty script provided" );
     }
     this.script = script;
   }
@@ -61,12 +65,14 @@ class ExecuteString extends Execute {
    * @throws IllegalArgumentException
    * @see org.apache.maven.plugins.scripting.Execute#constructEngine(javax.script.ScriptEngineManager)
    */
-  protected ScriptEngine constructEngine(ScriptEngineManager manager) throws IllegalArgumentException {
+  protected ScriptEngine constructEngine( ScriptEngineManager manager ) throws IllegalArgumentException
+  {
     ScriptEngine result;
 
     result = manager.getEngineByName( engineName );
-    if ( result == null ) {
-      throw new IllegalArgumentException( "Unknown engine specified with name \""+engineName+"\"" );
+    if ( result == null )
+    {
+      throw new IllegalArgumentException( "Unknown engine specified with name \"" + engineName + "\"" );
     }
     return result;
   }
@@ -74,7 +80,8 @@ class ExecuteString extends Execute {
   /**
    * @see org.apache.maven.plugins.scripting.Execute#execute(javax.script.ScriptEngine, javax.script.ScriptContext)
    */
-  protected Object execute(ScriptEngine engine, ScriptContext context) throws ScriptException {
+  protected Object execute( ScriptEngine engine, ScriptContext context ) throws ScriptException
+  {
     return engine.eval( script, context );
   }
 }

--- a/src/main/java/org/apache/maven/plugins/scripting/ExecuteString.java
+++ b/src/main/java/org/apache/maven/plugins/scripting/ExecuteString.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.maven.plugins.scripting;
+
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+
+/**
+ * Execute a script held in a string
+ * @author Rusi Popov
+ */
+class ExecuteString extends Execute {
+
+  /**
+   * Not null name of the engine to execute the script
+   */
+  private final String engineName;
+
+  /**
+   * The non-null script itself
+   */
+  private final String script;
+
+  /**
+   * @param engineName
+   * @param script
+   * @throws IllegalArgumentException
+   */
+  public ExecuteString(String engineName, String script) throws IllegalArgumentException {
+    if (engineName == null || engineName.trim().isEmpty()) {
+      throw new IllegalArgumentException("Expected a non-empty engine name provided");
+    }
+    this.engineName = engineName;
+
+    if (script == null || script.trim().isEmpty()) {
+      throw new IllegalArgumentException("Expected a non-empty script provided");
+    }
+    this.script = script;
+  }
+
+  /**
+   * @throws IllegalArgumentException
+   * @see org.apache.maven.plugins.scripting.Execute#constructEngine(javax.script.ScriptEngineManager)
+   */
+  protected ScriptEngine constructEngine(ScriptEngineManager manager) throws IllegalArgumentException {
+    ScriptEngine result;
+
+    result = manager.getEngineByName( engineName );
+    if ( result == null ) {
+      throw new IllegalArgumentException( "Unknown engine specified with name \""+engineName+"\"" );
+    }
+    return result;
+  }
+
+  /**
+   * @see org.apache.maven.plugins.scripting.Execute#execute(javax.script.ScriptEngine, javax.script.ScriptContext)
+   */
+  protected Object execute(ScriptEngine engine, ScriptContext context) throws ScriptException {
+    return engine.eval( script, context );
+  }
+}


### PR DESCRIPTION
Once MSCRIPTING JIRA project is not public, I was not able to register a JIRA issue for this change.
Added <scriptFile> parameter to maven-scripting-plugin, allowing the identification of the engine to use to use the file name extension, while still allowing explicitly naming the engine by providing <engineName>. Internally refactored to have a cleaner structure, allowing more extensions.